### PR TITLE
Make object detection possible in simulation.

### DIFF
--- a/pr2_pbd_interaction/launch/pbd_demo_robot.launch
+++ b/pr2_pbd_interaction/launch/pbd_demo_robot.launch
@@ -4,9 +4,10 @@
   <arg name="isReload" value="False" />
   <arg name="dataRoot" value="$(env HOME)" />
   <arg name="experimentNumber" value="3" />
-  
+  <arg name="sim" default="false" />
+
   <!-- This runs the interactive manipulation -->
-  
+
   <node pkg="pr2_arm_kinematics" type="pr2_arm_kinematics_node" name="pr2_left_arm_kinematics_simple" output="screen">
    <param name="tip_name" value="l_wrist_roll_link" />
    <param name="root_name" value="torso_lift_link" />
@@ -18,9 +19,9 @@
    <param name="root_name" value="torso_lift_link" />
    <param name="maxIterations" value="10000" />
   </node>
-  
+
   <include file="$(find pr2_interactive_manipulation)/launch/pr2_interactive_manipulation_robot.launch" >
-    <arg name="sim" value="false" />
+    <arg name="sim" value="$(arg sim)" />
   </include>
 
   <node name="pr2_pbd_interaction" pkg="pr2_pbd_interaction" type="interaction.py" output="screen">
@@ -28,7 +29,7 @@
     <param name="isReload" value="$(arg isReload)" />
     <param name="experimentNumber" value="$(arg experimentNumber)" />
   </node>
-  
+
   <!-- This makes the robot look around appropriately -->
 
   <include file="$(find pr2_social_gaze)/launch/gaze.launch"/>
@@ -39,5 +40,5 @@
    <rosparam command="load" file="$(find trajectory_filter_server)/config/joint_limits.yaml"/>
    <rosparam command="load" file="$(find pr2_pbd_interaction)/config/filters.yaml"/>
   </node>
-      
+
 </launch>


### PR DESCRIPTION
This makes the 'sim' argument a parameter that can be passed in while launching PbD. This allows you to do object detection in simulation by enabling the simulated kinect. 

Running on the robot happens as usual. To run on the desktop, you can now do

``` bash
$ roslaunch pr2_pbd_interaction pbd_demo_robot.launch sim:=true
```

and you get object detection.

As a note, my editor automatically strips whitespace from line endings, so that's what the other changed lines are.
