### PR TITLE
Style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,13 @@ install:
     - export ROS_HOSTNAME=localhost
     - export ROS_MASTER_URI=http://localhost:11311
     - export ROBOT=sim
-# Add ROS repositories, setup keys, update
+# Add ROS & Gazebo repositories, setup keys, update, install, init basics
     - echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
     - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+    - echo "deb http://packages.osrfoundation.org/gazebo/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/gazebo-latest.list
+    - wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
     - yes | sudo apt-get -y update
-# Main installation, ROS setup
-    - yes | sudo apt-get -y install ${ROS_CI_PREFIX}desktop-full
+    - yes | sudo apt-get -y install ${ROS_CI_PREFIX}desktop gazebo
     - sudo rosdep init
     - rosdep update
 # Environment setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,10 @@ install:
 # Command to run tests
 # --------------------
 script:
-# Debug: trying to just run gazebo's table object launch
-    - roslaunch pr2_pbd_interaction simulated_robot.launch gui:=false
+# Real tests: crash because of Gazebo bugs
+#    - roslaunch pr2_pbd_interaction simulated_robot.launch gui:=false
+# Debug: trying to just run gazebo's table object launch (Gazebo bugs)
 #    - rostest pr2_pbd_interaction test_endtoend.test
+# Linter: last resort to getting *something* useful to run on Travis :-)
+# NOTE(mbforbes): Add more files to this as they're completed.
+    - pep8 pr2_pbd_interaction/src/interaction.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,11 @@ install:
     - export ROS_HOSTNAME=localhost
     - export ROS_MASTER_URI=http://localhost:11311
     - export ROBOT=sim
-# Add ROS & Gazebo repositories, setup keys, update, install, init basics
+# Add ROS repositories, setup keys, update, install, init basics
     - echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
     - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-    - echo "deb http://packages.osrfoundation.org/gazebo/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/gazebo-latest.list
-    - wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
     - yes | sudo apt-get -y update
-    - yes | sudo apt-get -y install ${ROS_CI_PREFIX}desktop gazebo
+    - yes | sudo apt-get -y install ${ROS_CI_PREFIX}desktop-full
     - sudo rosdep init
     - rosdep update
 # Environment setup
@@ -63,10 +61,7 @@ install:
 # Make messages
     - cd pr2_pbd
     - rosmake
-# Debug; gazebo info
-    - which gazebo | xargs ls -la
-    - which gzserver
-    - which gzclient
+
 # Command to run tests
 # --------------------
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,6 @@ install:
 # Command to run tests
 # --------------------
 script:
-    - rostest pr2_pbd_interaction test_endtoend.test
+# Debug: trying to just run gazebo's table object launch
+    - roslaunch pr2_pbd_interaction simulated_robot.launch gui:=false
+#    - rostest pr2_pbd_interaction test_endtoend.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # Before anything, see if we can get the mongoDB troubles out of the way.
-    - sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
+    - sudo apt-get update
+    - yes | sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws
     - cd ..; mv pr2_pbd ~/rosbuild_ws/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,58 @@
+# General setup
+# -------------
 language: python
 python:
     - "2.7"
+# Allows the python virtualenv to use apt-get installed packages, which
+# is essential (as ROS recommends this and pip doesn't seem to contain
+# all packages, or contains them with errors).
 virtualenv:
     system_site_packages: true
-# Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
+# Allow caching of debian (apt-get) packages. This means they're cached
+# on Travis, so we still have to download/install them, but it will be
+# faster than going to the ubuntu repositories.
+cache: apt
+# Git settings.
+# NOTE(mbforbes): Change this to groovy-devel when moving to PR2 repo.
+branches:
+    only:
+        - style
 # Before anything, see if we can get the mongoDB troubles out of the way.
-    - sudo apt-get update
+# Note that this is a Travis-CI specific problem; this is not needed in
+# general.
+before_install:
     - sudo apt-get --purge remove mongodb-10gen
+
+# Commands to install dependencies
+# --------------------------------
+install:
+# Update package list and install new versions.
+    - sudo apt-get update
     - sudo apt-get upgrade
-    - yes | sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
-# First, move code to correct place
+# First, move code to correct place. Also Travis-CI specific.
     - mkdir -p ~/rosbuild_ws
     - cd ..; mv pr2_pbd ~/rosbuild_ws/
-# Settings + Debug
+# Settings to make installing script more general.
     - export ROS_CI_DESKTOP=`lsb_release -cs`  # e.g. 'precise'
     - export ROS_CI_VERSION=groovy  # e.g. 'groovy'
     - export ROS_CI_PREFIX=ros-${ROS_CI_VERSION}-  # e.g. 'ros-groovy-'
-# Exports for scripts
+# Exports for ROS
     - export ROS_HOSTNAME=localhost
     - export ROS_MASTER_URI=http://localhost:11311
     - export ROBOT=sim
 # Add ROS repositories, setup keys, update
     - echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
     - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-    - sudo apt-get update
+    - yes | sudo apt-get -y update
 # Main installation, ROS setup
-    - sudo apt-get install ${ROS_CI_PREFIX}desktop-full
+    - yes | sudo apt-get -y install ${ROS_CI_PREFIX}desktop-full
     - sudo rosdep init
     - rosdep update
 # Environment setup
     - source /opt/ros/${ROS_CI_VERSION}/setup.bash
-# Add required PR2/desktop packages.
-# (These can be compressed into one command, but this is easier to maintain.)
-    - sudo apt-get -y install ${ROS_CI_PREFIX}simulator-gazebo
-    - sudo apt-get -y install ${ROS_CI_PREFIX}openni-launch
-    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-interactive-manipulation
-    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-simulator
-    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-desktop
-    - sudo apt-get -y install ${ROS_CI_PREFIX}pocketsphinx
-    - sudo apt-get -y install python-rosinstall
-# Add required python packages
+# Add required debian and python packages with apt-get and pip.
     - cd ~/rosbuild_ws/pr2_pbd
+    - yes | sudo apt-get -y install $(< packages.txt)
     - pip install -r requirements.txt
 # Initialize ROS workspace, setup, set path
     - cd ~/rosbuild_ws
@@ -51,10 +62,8 @@ install:
 # Make messages
     - cd pr2_pbd
     - rosmake
+
 # Command to run tests
+# --------------------
 script:
     - rostest pr2_pbd_interaction test_endtoend.test
-# NOTE(mbforbes): Change this to groovy-devel when moving to PR2 repo.
-branches:
-    only:
-        - style

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,11 @@ install:
 # Add required python packages
     - cd ~/rosbuild_ws/pr2_pbd
     - pip install -r requirements.txt --use-mirrors
-# Initialize ROS workspace
+# Initialize ROS workspace, setup, set path
     - cd ~/rosbuild_ws
     - rosws init . /opt/ros/${ROS_CI_VERSION}
     - source ~/rosbuild_ws/setup.bash
+    - export ROS_PACKAGE_PATH=~/rosbuild_ws/:/opt/ros/${ROS_CI_VERSION}/share:/opt/ros/${ROS_CI_VERSION}/stacks
 # Make messages
     - cd pr2_pbd
     - rosmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
 # Before anything, see if we can get the mongoDB troubles out of the way.
     - sudo apt-get update
+    - sudo apt-get --purge remove mongodb-10gen
     - yes | sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws
@@ -29,12 +30,14 @@ install:
     - source /opt/ros/${ROS_CI_VERSION}/setup.bash
 # Add required PR2/desktop packages.
 # (These can be compressed into one command, but this is easier to maintain.)
-    - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
-    - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
+    - sudo apt-get -y install ${ROS_CI_PREFIX}simulator-gazebo
+    - sudo apt-get -y install ${ROS_CI_PREFIX}openni-launch
+    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-interactive-manipulation
+    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-simulator
+    - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-desktop
+    - sudo apt-get -y install python-rosinstall
 # Add required python packages
+    - cd ~/rosbuild_ws/pr2_pbd
     - pip install -r requirements.txt --use-mirrors
 # Initialize ROS workspace
     - cd ~/rosbuild_ws

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ install:
     - source ~/.bashrc
 # Add required PR2/desktop packages.
 # (These can be compressed into one command, but this is easier to maintain.)
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
     - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
     - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
 # Add required python packages
     - pip install -r requirements.txt --use-mirrors
 # Initialize ROS workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 # Before anything, see if we can get the mongoDB troubles out of the way.
     - sudo apt-get update
     - sudo apt-get --purge remove mongodb-10gen
+    - sudo apt-get upgrade
     - yes | sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
     - "2.7"
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+# Before anything, see if we can get the mongoDB troubles out of the way.
+    - sudo apt-get install mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws
     - cd ..; mv pr2_pbd ~/rosbuild_ws/
@@ -15,28 +17,22 @@ install:
     - export ROS_MASTER_URI=http://localhost:11311
     - export ROBOT=sim
 # Add ROS repositories, setup keys, update
-    - echo "deb http://packages.ros.org/ros/ubuntu ${ROS_CI_DESKTOP} main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
+    - echo "deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
     - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
     - sudo apt-get update
 # Main installation, ROS setup
-# Trying rosdep instead. Previously:    - sudo apt-get install ${ROS_CI_PREFIX}desktop-full
-    - sudo apt-get install python-rosdep
+    - sudo apt-get install ${ROS_CI_PREFIX}desktop-full
     - sudo rosdep init
     - rosdep update
-# rviz's comamnd not working
-#    - rosdep install --default-yes --from-paths ./  --rosdistro $ROS_CI_VERSION
-# This might do it
-    - rosdep install pr2_pbd
 # Environment setup
     - source /opt/ros/${ROS_CI_VERSION}/setup.bash
 # Add required PR2/desktop packages.
 # (These can be compressed into one command, but this is easier to maintain.)
-# NOTE(mbforbes): Trying rosdep instead (above). Previous commands are below.
-#    - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
-#    - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
-#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
-#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
-#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
+    - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
+    - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
+    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
 # Add required python packages
     - pip install -r requirements.txt --use-mirrors
 # Initialize ROS workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,9 @@ install:
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-simulator
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-desktop
     - sudo apt-get -y install python-rosinstall
-    - sudo apt-get -y install python-rospkg
 # Add required python packages
     - cd ~/rosbuild_ws/pr2_pbd
-    - pip install -r requirements.txt --use-mirrors
+    - pip install -r requirements.txt
 # Initialize ROS workspace, setup, set path
     - cd ~/rosbuild_ws
     - rosws init . /opt/ros/${ROS_CI_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,8 @@ install:
 # Make messages
     - cd pr2_pbd
     - rosmake
-
+# Debug; gazebo info
+    - which gazebo | xargs ls -la
 # Command to run tests
 # --------------------
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-simulator
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-desktop
     - sudo apt-get -y install python-rosinstall
+    - sudo apt-get -y install python-rospkg
 # Add required python packages
     - cd ~/rosbuild_ws/pr2_pbd
     - pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+virtualenv:
+    system_site_packages: true
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # Before anything, see if we can get the mongoDB troubles out of the way.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 python:
     - "2.7"
-# Adding mongodb to services, hoping this will fix the install issue...
-services:
-    - mongodb
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # First, move code to correct place
@@ -11,44 +8,37 @@ install:
     - cd ..; mv pr2_pbd ~/rosbuild_ws/
 # Settings + Debug
     - export ROS_CI_DESKTOP=`lsb_release -cs`  # e.g. 'precise'
-    - echo $ROS_CI_DESKTOP
     - export ROS_CI_VERSION=groovy  # e.g. 'groovy'
-    - echo $ROS_CI_VERSION
     - export ROS_CI_PREFIX=ros-${ROS_CI_VERSION}-  # e.g. 'ros-groovy-'
-    - echo $ROS_CI_PREFIX
 # Exports for scripts
     - export ROS_HOSTNAME=localhost
-    - echo $ROS_HOSTNAME
     - export ROS_MASTER_URI=http://localhost:11311
-    - echo $ROS_MASTER_URI
     - export ROBOT=sim
-    - echo $ROBOT
 # Add ROS repositories, setup keys, update
     - echo "deb http://packages.ros.org/ros/ubuntu ${ROS_CI_DESKTOP} main" | sudo tee /etc/apt/sources.list.d/ros-latest.list
     - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
-# Debug
-    - sudo cat /etc/apt/sources.list.d/ros-latest.list
-# /Debug
     - sudo apt-get update
 # Main installation, ROS setup
-    - sudo apt-get install ${ROS_CI_PREFIX}desktop-full
+# Trying rosdep instead. Previously:    - sudo apt-get install ${ROS_CI_PREFIX}desktop-full
+    - sudo apt-get install python-rosdep
     - sudo rosdep init
     - rosdep update
+    - rosdep install --default-yes --from-paths ./  --rosdistro $ROS_CI_VERSION
 # Environment setup
-    - echo "source /opt/ros/${ROS_CI_VERSION}/setup.bash" >> ~/.bashrc
-    - source ~/.bashrc
+    - source /opt/ros/${ROS_CI_VERSION}/setup.bash"
 # Add required PR2/desktop packages.
 # (These can be compressed into one command, but this is easier to maintain.)
-    - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
-    - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
-    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
+# NOTE(mbforbes): Trying rosdep instead (above). Previous commands are below.
+#    - sudo apt-get install ${ROS_CI_PREFIX}simulator-gazebo
+#    - sudo apt-get install ${ROS_CI_PREFIX}openni-launch
+#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-interactive-manipulation
+#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-simulator
+#    - sudo apt-get install ${ROS_CI_PREFIX}pr2-desktop
 # Add required python packages
     - pip install -r requirements.txt --use-mirrors
 # Initialize ROS workspace
     - cd ~/rosbuild_ws
-    - rosws init . /open/ros/${ROS_CI_VERSION}
+    - rosws init . /opt/ros/${ROS_CI_VERSION}
 # Make messages
     - cd pr2_pbd
     - rosmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # Before anything, see if we can get the mongoDB troubles out of the way.
-    - sudo apt-mark hold mongodb-clients mongodb-dev mongodb-server
+    - sudo apt-get -y install mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws
     - cd ..; mv pr2_pbd ~/rosbuild_ws/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
     - "2.7"
+# Adding mongodb to services, hoping this will fix the install issue...
+services:
+    - mongodb
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # First, move code to correct place

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ install:
     - sudo apt-get install python-rosdep
     - sudo rosdep init
     - rosdep update
-    - rosdep install --default-yes --from-paths ./  --rosdistro $ROS_CI_VERSION
+# rviz's comamnd not working
+#    - rosdep install --default-yes --from-paths ./  --rosdistro $ROS_CI_VERSION
+# This might do it
+    - rosdep install pr2_pbd
 # Environment setup
-    - source /opt/ros/${ROS_CI_VERSION}/setup.bash"
+    - source /opt/ros/${ROS_CI_VERSION}/setup.bash
 # Add required PR2/desktop packages.
 # (These can be compressed into one command, but this is easier to maintain.)
 # NOTE(mbforbes): Trying rosdep instead (above). Previous commands are below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # Before anything, see if we can get the mongoDB troubles out of the way.
-    - sudo apt-get install mongodb-clients mongodb-dev mongodb-server
+    - sudo apt-mark hold mongodb-clients mongodb-dev mongodb-server
 # First, move code to correct place
     - mkdir -p ~/rosbuild_ws
     - cd ..; mv pr2_pbd ~/rosbuild_ws/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ install:
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-interactive-manipulation
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-simulator
     - sudo apt-get -y install ${ROS_CI_PREFIX}pr2-desktop
+    - sudo apt-get -y install ${ROS_CI_PREFIX}pocketsphinx
     - sudo apt-get -y install python-rosinstall
 # Add required python packages
     - cd ~/rosbuild_ws/pr2_pbd

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
 # Initialize ROS workspace
     - cd ~/rosbuild_ws
     - rosws init . /opt/ros/${ROS_CI_VERSION}
+    - source ~/rosbuild_ws/setup.bash
 # Make messages
     - cd pr2_pbd
     - rosmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,9 @@ install:
     - cd pr2_pbd
     - rosmake
 # Debug; gazebo info
-    - which gazebo | xargs ls -la
+    - `which gazebo` | xargs ls -la
+    - which gzserver
+    - which gzclient
 # Command to run tests
 # --------------------
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
     - cd pr2_pbd
     - rosmake
 # Debug; gazebo info
-    - `which gazebo` | xargs ls -la
+    - which gazebo | xargs ls -la
     - which gzserver
     - which gzclient
 # Command to run tests

--- a/README.md
+++ b/README.md
@@ -139,13 +139,15 @@ $ roslaunch pr2_pbd_interaction pbd_simulation_stack.launch
 
 
 ## Tests
+0. Lint your Python to pep8 standards by running `pep8 file1 file2 ...`.
+
 0. Run the tests with `rostest pr2_pbd_interaction test_endtoend.test`.
 
 0. View code coverage by opening `~/.ros/htmlcov/index.html` with a web broswer.
 
 0. With an acout setup at [Coveralls](https://coveralls.io), edit the `.coveralls.yml` with your repo_token, and track coverage there by running `coveralls --data_file ~/.ros/.coverage`.
 
-To do all of these steps automatically (opening with Google Chrome, assuming Coveralls and `.coveralls.yml` setup), we have provided a script:
+To do all of these steps automatically (linting common directories, opening coverage report with Google Chrome, assuming Coveralls and `.coveralls.yml` correctly setup), we have provided a script:
 ```bash
 $ roscd pr2_pbd_interaction; ./scripts/test_and_coverage.sh
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ sudo apt-get install python-pip
 
 The required pip packages are listed in `requirements.txt`. From the root of the repository, run:
 ```bash
-$ pip install -r requirements.txt --use-mirrors
+$ pip install -r requirements.txt
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The required python packages are listed in `requirements.txt` and can be install
 ```bash
 $ pip install -r requirements.txt
 ```
+Note that if you use python with virtualenv, you want it to still find the apt-get installed python packages, as not all are available or work property with pip. Do this by starting virtualenv with: `virtualenv --system-site-packages ENV` ([more info](http://virtualenv.readthedocs.org/en/latest/virtualenv.html#the-system-site-packages-option)).
 
 ### PbD code
 Do the following to checkout and make the PBD code:
@@ -117,13 +118,13 @@ $ roslaunch pr2_pbd_interaction pbd_backend.launch
 #### Commands on desktop
 ```bash
 # Terminal 1: PR2 dashboard
-$ realrobot  # see 'Prerequisites' section above
+$ realrobot  # points ROS to PR2
 $ rosrun rqt_pr2_dashboard rqt_pr2_dashboard  # dashboard to monitor PR2
 # Make sure both runstops are OK (far right icon), and motors OK (red gear icon)
 
 # Terminal 2: PbD frontend
-$ realrobot  # see 'Prerequisites' section above
-$ roslaunch pr2_pbd_interaction pbd_frontend.launch
+$ realrobot  # points ROS to PR2
+$ roslaunch pr2_pbd_interaction pbd_frontend.launch  # rviz, rqt, speech
 ```
 
 ### On desktop only (simulation)

--- a/README.md
+++ b/README.md
@@ -19,66 +19,89 @@ We are currently (this text written summer 2014) working on ROS Hydro and Catkin
 
 
 ## Installing
+Note: Unless otherwise stated, all commands should be run from the root of this repository.
 
-### ROS Software
-- [Install ROS Groovy](http://wiki.ros.org/groovy/Installation/Ubuntu) (ros-groovy-desktop-full) on your Ubuntu 12.04 (precise) machine.
+If you go through these instructions and your installation is not working, check out the `install:` section of our `.travis.yml` build script. It contains all commands needed to get up-and-running from a barebones Ubuntu 12.04 installation.
 
-- Use apt-get to install the following ROS packages:
-	- `ros-groovy-pr2-desktop`
-	- `ros-groovy-interactive-manipulation`
-	- `ros-groovy-simulator-gazebo`
-	- `ros-groovy-pr2-simulator`
-	- `ros-groovy-openni-launch`
-
-- As a note, [here is a list](https://gist.github.com/mbforbes/a1580f5434e35c597108) of all packages you may need on your desktop; if it's not running, check against that list.
-
-### PbD Code
-Assuming you've set up a rosbuild workspace in the location `~/rosbuild_ws`, and you've correctly `source`'d the correct ROS Groovy setup files, you do the following:
-
+### Ubuntu setup
+An up-to-date Ubuntu 12.04 machine should do fine, but just to make sure that you've got everything you need, run the following commands:
 ```bash
-$ cd ~/rosbuild_ws  # or your rosbuild workspace
-$ git clone git@github.com:PR2/pr2_pbd.git  # or your fork
-$ cd pr2_pbd
-$ rosmake  # generate message classes
+# Update software list and install new versions.
+$ sudo apt-get update
+$ sudo apt-get upgrade
+
+# Install python requirements
+$ sudo apt-get install python2.7 python-pip
 ```
 
-Note that this needs to be done on **both** the PR2 _and_ your desktop machine.
+### ROS software
+[Install ROS Groovy](http://wiki.ros.org/groovy/Installation/Ubuntu) (pick `ros-groovy-desktop-full`) on your Ubuntu 12.04 (precise) machine. Make sure you follow all steps; we have omitted here everything contained in that guide.
 
-### Python packages
-If you don't have Python, install Python 2.7
+Additional required debian packages are listed in `packages.txt` and can be installed with apt-get:
+
 ```bash
-$ sudo apt-get install python2.7
+$ yes | sudo apt-get -y install $(< packages.txt)
 ```
 
-If you don't have pip, install pip
+### ROS setup
+
+#### Both PR2 (`c1`) and desktop
+First, you need to setup a `rosbuild` workspace.
+
 ```bash
-$ sudo apt-get install python-pip
+$ mkdir -p ~/rosbuild_ws  # Create your rosbuild workspace
+$ cd ~/rosbuild_ws && rosws init . /opt/ros/groovy  # Enter it and initialize
 ```
 
-The required pip packages are listed in `requirements.txt`. From the root of the repository, run:
+#### PR2 (`c1`) specific
+You need to set environment variables. In addition to running these commands, you should put them in your `~/.bashrc` file so terminals automatically run them.
+
 ```bash
-$ pip install -r requirements.txt
+$ source /opt/ros/groovy/setup.sh
+$ source ~/rosbuild_ws/setup.bash
+$ export ROS_ENV_LOADER=/etc/ros/groovy/env.sh
+$ export ROS_PACKAGE_PATH=~/rosbuild_ws:$ROS_PACKAGE_PATH
 ```
 
-
-
-## Running
-
-### Prerequisites
-Here we assume that, in addition to having ROS Groovy and your rosbuild workspace setup correctly, by default you have the following environment variables **on your desktop**:
+#### Desktop specific
+You need to set environment variables. In addition to running these commands, you should put them in your `~/.bashrc` file so terminals automatically run them.
 
 ```bash
+$ source ~/rosbuild_ws/setup.bash
+$ export ROS_PACKAGE_PATH=~/rosbuild_ws/:$ROS_PACKAGE_PATH
 $ export ROS_HOSTNAME=localhost
 $ export ROS_MASTER_URI=http://localhost:11311
 $ export ROBOT=sim
 $ export MY_IP=$(/sbin/ifconfig eth0 | awk '/inet/ { print $2 } ' | sed -e s/addr://)
 ```
 
-and that you have some way of pointing your desktop to look at the PR2 (`c1`) as the ROS master, such as this alias:
+Finally, for running on the PR2, you need some way of pointing your desktop to look at the PR2 (`c1`) as the ROS master. Put this alias in your `~/.bashrc` or `~/.bash_aliases`:
 
 ```bash
 $ alias realrobot='unset ROBOT; unset ROS_HOSTNAME; export ROS_MASTER_URI=http://c1:11311; export ROS_IP=$MY_IP'
 ```
+
+### Python setup
+The required python packages are listed in `requirements.txt` and can be installed with pip:
+
+```bash
+$ pip install -r requirements.txt
+```
+
+### PbD code
+Do the following to checkout and make the PBD code:
+
+```bash
+$ cd ~/rosbuild_ws  # or your rosbuild workspace
+$ git clone git@github.com:PR2/pr2_pbd.git  # or your fork
+$ cd pr2_pbd && rosmake  # generate message classes
+```
+
+Note that this needs to be done on **both** the PR2 _and_ your desktop machine.
+
+
+
+## Running
 
 ### On the PR2
 
@@ -90,6 +113,7 @@ $ robot claim; robot stop; robot start  # gets the robot
 # Before continuing, complete Terminal 1 on desktop to ensure the PR2 is ready.
 $ roslaunch pr2_pbd_interaction pbd_backend.launch
 ```
+
 #### Commands on desktop
 ```bash
 # Terminal 1: PR2 dashboard
@@ -114,7 +138,11 @@ $ roslaunch pr2_pbd_interaction pbd_simulation_stack.launch
 
 
 ## Tests
-Run the tests with `rostest pr2_pbd_interaction test_endtoend.test`. View code coverage by opening `~/.ros/htmlcov/index.html` with a web broswer. With an acout setup at [Coveralls](https://coveralls.io), edit the `.coveralls.yml` with your repo_token, and track coverage there by running `coveralls --data_file ~/.ros/.coverage`.
+0. Run the tests with `rostest pr2_pbd_interaction test_endtoend.test`.
+
+0. View code coverage by opening `~/.ros/htmlcov/index.html` with a web broswer.
+
+0. With an acout setup at [Coveralls](https://coveralls.io), edit the `.coveralls.yml` with your repo_token, and track coverage there by running `coveralls --data_file ~/.ros/.coverage`.
 
 To do all of these steps automatically (opening with Google Chrome, assuming Coveralls and `.coveralls.yml` setup), we have provided a script:
 ```bash

--- a/packages.txt
+++ b/packages.txt
@@ -5,3 +5,4 @@ ros-groovy-pr2-simulator
 ros-groovy-pr2-desktop
 ros-groovy-pocketsphinx
 python-rosinstall
+ros-groovy-gazebo-ros-current

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,7 @@
+ros-groovy-simulator-gazebo
+ros-groovy-openni-launch
+ros-groovy-pr2-interactive-manipulation
+ros-groovy-pr2-simulator
+ros-groovy-pr2-desktop
+ros-groovy-pocketsphinx
+python-rosinstall

--- a/packages.txt
+++ b/packages.txt
@@ -1,8 +1,7 @@
-ros-groovy-pr2-desktop
-ros-groovy-pr2-simulator
-ros-groovy-pr2-interactive-manipulation
+ros-groovy-simulator-gazebo
 ros-groovy-openni-launch
+ros-groovy-pr2-interactive-manipulation
+ros-groovy-pr2-simulator
+ros-groovy-pr2-desktop
 ros-groovy-pocketsphinx
 python-rosinstall
-ros-groovy-urdf
-ros-groovy-urdfdom

--- a/packages.txt
+++ b/packages.txt
@@ -1,8 +1,7 @@
-ros-groovy-simulator-gazebo
-ros-groovy-openni-launch
-ros-groovy-pr2-interactive-manipulation
-ros-groovy-pr2-simulator
 ros-groovy-pr2-desktop
+ros-groovy-pr2-simulator
+ros-groovy-pr2-interactive-manipulation
+ros-groovy-openni-launch
 ros-groovy-pocketsphinx
 python-rosinstall
 ros-groovy-urdf

--- a/packages.txt
+++ b/packages.txt
@@ -6,3 +6,5 @@ ros-groovy-pr2-desktop
 ros-groovy-pocketsphinx
 python-rosinstall
 ros-groovy-gazebo-ros-current
+ros-groovy-urdf
+ros-groovy-urdfdom

--- a/packages.txt
+++ b/packages.txt
@@ -5,6 +5,5 @@ ros-groovy-pr2-simulator
 ros-groovy-pr2-desktop
 ros-groovy-pocketsphinx
 python-rosinstall
-ros-groovy-gazebo-ros-current
 ros-groovy-urdf
 ros-groovy-urdfdom

--- a/pr2_pbd_interaction/launch/pbd_backend.launch
+++ b/pr2_pbd_interaction/launch/pbd_backend.launch
@@ -6,7 +6,7 @@
 	<!-- These arguments can be passed in. -->
 	<!-- ================================= -->
 	<!-- Should we reload a previously saved experiment state?  -->
-	<arg name="isReload" default="False" />
+	<arg name="isReload" default="false" />
 
 	<!-- Where is experiment state stored? -->
 	<arg name="dataRoot" default="$(env HOME)" />

--- a/pr2_pbd_interaction/manifest.xml
+++ b/pr2_pbd_interaction/manifest.xml
@@ -1,40 +1,40 @@
 <package>
-  <description brief="pr2_pbd_interaction">
+	<description brief="pr2_pbd_interaction">
 
-     The interaction framework for Programing by Demonstration.
+		 The interaction framework for Programing by Demonstration.
 
-  </description>
-  <author>Maya Cakmak</author>
-  <license>BSD</license>
-  <review status="unreviewed" notes=""/>
-  <url>http://ros.org/wiki/pr2_pbd</url>
+	</description>
+	<author>Maya Cakmak</author>
+	<license>BSD</license>
+	<review status="unreviewed" notes=""/>
+	<url>http://ros.org/wiki/pr2_pbd</url>
 
-  <depend package="actionlib"/>
-  <depend package="arm_navigation_msgs"/>
-  <depend package="geometry_msgs"/>
-  <depend package="interactive_markers"/>
-  <depend package="kinematics_msgs"/>
-  <depend package="object_manipulation_msgs"/>
-  <depend package="pr2_arm_kinematics"/>
-  <depend package="pr2_controllers_msgs"/>
-  <depend package="pr2_gazebo"/>
-  <depend package="pr2_gripper_sensor_msgs"/>
-  <depend package="pr2_interactive_manipulation"/>
-  <depend package="pr2_interactive_manipulation_frontend"/>
-  <depend package="rviz"/>
-  <depend package="pr2_interactive_object_detection"/>
-  <depend package="pr2_mechanism_controllers"/>
-  <depend package="pr2_mechanism_msgs"/>
-  <depend package="pr2_pbd_speech_recognition"/>
-  <depend package="pr2_social_gaze"/>
-  <depend package="rospy"/>
-  <depend package="rostest"/>
-  <depend package="rqt_gui"/>
-  <depend package="sound_play"/>
-  <depend package="std_msgs"/>
-  <depend package="tabletop_collision_map_processing"/>
-  <depend package="tf"/>
-  <depend package="tf_throttle"/>
-  <depend package="trajectory_filter_server"/>
-  <depend package="visualization_msgs"/>
+	<depend package="actionlib"/>
+	<depend package="arm_navigation_msgs"/>
+	<depend package="geometry_msgs"/>
+	<depend package="interactive_markers"/>
+	<depend package="kinematics_msgs"/>
+	<depend package="object_manipulation_msgs"/>
+	<depend package="pr2_arm_kinematics"/>
+	<depend package="pr2_controllers_msgs"/>
+	<depend package="pr2_gazebo"/>
+	<depend package="pr2_gripper_sensor_msgs"/>
+	<depend package="pr2_interactive_manipulation"/>
+	<depend package="pr2_interactive_manipulation_frontend"/>
+	<depend package="rviz"/>
+	<depend package="pr2_interactive_object_detection"/>
+	<depend package="pr2_mechanism_controllers"/>
+	<depend package="pr2_mechanism_msgs"/>
+	<depend package="pr2_pbd_speech_recognition"/>
+	<depend package="pr2_social_gaze"/>
+	<depend package="rospy"/>
+	<depend package="rostest"/>
+	<depend package="rqt_gui"/>
+	<depend package="sound_play"/>
+	<depend package="std_msgs"/>
+	<depend package="tabletop_collision_map_processing"/>
+	<depend package="tf"/>
+	<depend package="tf_throttle"/>
+	<depend package="trajectory_filter_server"/>
+	<depend package="visualization_msgs"/>
 </package>

--- a/pr2_pbd_interaction/manifest.xml
+++ b/pr2_pbd_interaction/manifest.xml
@@ -38,5 +38,3 @@
   <depend package="trajectory_filter_server"/>
   <depend package="visualization_msgs"/>
 </package>
-
-

--- a/pr2_pbd_interaction/scripts/test_and_coverage.sh
+++ b/pr2_pbd_interaction/scripts/test_and_coverage.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 #
-# Script to run tests, view coverage results, and upload to Coveralls.
+# Script to
+# - lint files with pep8 linter
+# - run tests
+# - view coverage results in Google Chrome
+# - upload coverage results to Coveralls
+roscd pr2_pbd_gui; pep8 src/pr2_pbd_gui/*.py
+roscd pr2_pbd_interaction; pep8 src/*.py nodes/*.py test/*.py
+roscd pr2_pbd_speech_recognition; pep8 nodes/*.py scripts/*.py
+roscd pr2_social_gaze; pep8 nodes/*.py
 rostest pr2_pbd_interaction test_endtoend.test
 google-chrome ~/.ros/htmlcov/index.html
 coveralls --data_file ~/.ros/.coverage

--- a/pr2_pbd_interaction/test/test_endtoend.test
+++ b/pr2_pbd_interaction/test/test_endtoend.test
@@ -15,6 +15,6 @@
 	</include>
 
 	<!-- Run the tests themselves. -->
-	<test test-name="test_endtoend" pkg="pr2_pbd_interaction" type="test_endtoend.py" ns="pr2_pbd_interaction" time-limit="600.0">
+	<test test-name="test_endtoend" pkg="pr2_pbd_interaction" type="test_endtoend.py" ns="pr2_pbd_interaction" time-limit="3600.0">
 	</test>
 </launch>

--- a/pr2_pbd_interaction/test/test_endtoend.test
+++ b/pr2_pbd_interaction/test/test_endtoend.test
@@ -15,6 +15,6 @@
 	</include>
 
 	<!-- Run the tests themselves. -->
-	<test test-name="test_endtoend" pkg="pr2_pbd_interaction" type="test_endtoend.py" ns="pr2_pbd_interaction">
+	<test test-name="test_endtoend" pkg="pr2_pbd_interaction" type="test_endtoend.py" ns="pr2_pbd_interaction" time-limit="600.0">
 	</test>
 </launch>

--- a/pr2_pbd_speech_recognition/manifest.xml
+++ b/pr2_pbd_speech_recognition/manifest.xml
@@ -15,7 +15,6 @@
 	<review status="unreviewed" notes=""/>
 	<url>http://ros.org/wiki/pr2_pbd_speech_recognition</url>
 
-	<depend package="pocketsphinx"/>
 	<depend package="std_msgs"/>
 	<depend package="rospy"/>
 </package>

--- a/pr2_pbd_speech_recognition/manifest.xml
+++ b/pr2_pbd_speech_recognition/manifest.xml
@@ -1,23 +1,21 @@
 <package>
-  <description brief="pr2_pbd_speech_recognition">
+	<description brief="pr2_pbd_speech_recognition">
 
-     pr2_pbd_speech_recognition
+		 pr2_pbd_speech_recognition
 
-     1. Update msg/Command.msg with your list of commands
-     2. Run the script to generate the command corpus automatically: $ ./scripts/generate_corpus.py
-     3. Upload data/commands.corpus at http://www.speech.cs.cmu.edu/tools/lmtool.html and compile the knowledge base.
-     4. Download the generated Dictionary as data/commands.dic and the Language Model as data/commands.lm
-     5. Make
+		 1. Update msg/Command.msg with your list of commands
+		 2. Run the script to generate the command corpus automatically: $ ./scripts/generate_corpus.py
+		 3. Upload data/commands.corpus at http://www.speech.cs.cmu.edu/tools/lmtool.html and compile the knowledge base.
+		 4. Download the generated Dictionary as data/commands.dic and the Language Model as data/commands.lm
+		 5. Make
 
-  </description>
-  <author>Maya Cakmak</author>
-  <license>BSD</license>
-  <review status="unreviewed" notes=""/>
-  <url>http://ros.org/wiki/pr2_pbd_speech_recognition</url>
-  <depend package="pocketsphinx"/>
-  <depend package="std_msgs"/>
-  <depend package="rospy"/>
+	</description>
+	<author>Maya Cakmak</author>
+	<license>BSD</license>
+	<review status="unreviewed" notes=""/>
+	<url>http://ros.org/wiki/pr2_pbd_speech_recognition</url>
 
+	<depend package="pocketsphinx"/>
+	<depend package="std_msgs"/>
+	<depend package="rospy"/>
 </package>
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-numpy
-scipy
 coverage
 python-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 coverage
 python-coveralls
-rospkg
-catkin-pkg
-rosdep

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coverage
 python-coveralls
+pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 coverage
 python-coveralls
 rospkg
+catkin-pkg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 coverage
 python-coveralls
+rospkg

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ coverage
 python-coveralls
 rospkg
 catkin-pkg
+rosdep


### PR DESCRIPTION
Before you merge, can you (or I can with you):  
- hook up [Travis](http://travis-ci.org) with the PR2/pr2_pbd repository
- hook up [coveralls](http://coveralls.io) with the PR2/pr2_pbd repository

I would do this but I don't because I'm not a collaborator on those repos.

This pull sets up pr2_pbd to be installed on Travis (continuous integration). It also updates the README and does some small other cosmetic changes.

After many hours of attempting, I finally got everything to install on the Travis automated build system. However, the tests will not run. This is because the Gazebo version we use won't run there due to some bug. So, the tests it runs automatically are just linters.

The true tests and coverage can still be run/computed locally.
